### PR TITLE
Add 'migrate tenant' subcommand.

### DIFF
--- a/coriolis_openstack_utils/cli/migrations.py
+++ b/coriolis_openstack_utils/cli/migrations.py
@@ -39,13 +39,6 @@ class MigrationFormatter(formatter.EntityFormatter):
 class CreateMigrations(lister.Lister):
     def get_parser(self, prog_name):
         parser = super(CreateMigrations, self).get_parser(prog_name)
-
-        parser.add_argument(
-            "--dont-recreate-tenants",
-            dest="dont_recreate_tenants", default=False, action="store_true",
-            help="Whether or not to use existing tenants on the destination, "
-                 "or attempt to create a new corrresponding one for each "
-                 "source tenant.")
         parser.add_argument(
             "--batch-name", dest="batch_name",
             default="MigrationBatch",
@@ -69,8 +62,7 @@ class CreateMigrations(lister.Lister):
         batch_name = args.batch_name
         migration_payload = {
             "instances": source_vms,
-            "batch_name": batch_name,
-            "create_tenants": not args.dont_recreate_tenants}
+            "batch_name": batch_name}
         batch_migration_action = (
             coriolis_transfer_actions.BatchMigrationAction(
                 migration_payload, source_openstack_client=source_client,

--- a/coriolis_openstack_utils/cli/tenant.py
+++ b/coriolis_openstack_utils/cli/tenant.py
@@ -1,0 +1,105 @@
+# Copyright 2018 Cloudbase Solutions Srl
+# All Rights Reserved.
+
+from oslo_log import log as logging
+
+from cliff import lister
+
+from coriolis_openstack_utils import conf
+from coriolis_openstack_utils.actions import tenant_actions
+from coriolis_openstack_utils.cli import formatter
+
+
+LOG = logging.getLogger(__name__)
+
+
+class TenantMigrationFormatter(formatter.EntityFormatter):
+    columns = (
+        "Tenant Name",
+        "Tenant ID")
+
+    def _get_formatted_data(self, obj):
+        data = (
+            obj["name"],
+            obj["id"])
+
+        return data
+
+
+class MigrateTenant(lister.Lister):
+    def get_parser(self, prog_name):
+        parser = super(MigrateTenant, self).get_parser(prog_name)
+        source_group = parser.add_mutually_exclusive_group(required=True)
+        source_group.add_argument(
+            "--source-tenant-id",
+            dest="src_tenant_id",
+            help="The tenant id of the security group that is being migrated.")
+        source_group.add_argument(
+            "--source-tenant-name", dest="src_tenant_name",
+            help="The tenant name of the security group that is being "
+                 "migrated.")
+        instance_options = parser.add_mutually_exclusive_group(required=True)
+        instance_options.add_argument(
+            "--all-instances", dest="all_instances", action="store_true",
+            help="Migrate all instances from source to destination tenant.")
+        instance_options.add_argument(
+            "--no-instances", dest="no_instances", action="store_true",
+            help="Do not migrate any source instances to the destination "
+                 "tenant.")
+        instance_options.add_argument(
+            "--instances", dest="instances", nargs='+',
+            help="List of instance names to be migrated.")
+        parser.add_argument(
+            "--not-a-drill", dest="not_drill", action="store_true",
+            default=False,
+            help="If unset, tooling will only print the indented operations.")
+        return parser
+
+    def take_action(self, args):
+        # instantiate all clients:
+        source_client = conf.get_source_openstack_client()
+        destination_client = conf.get_destination_openstack_client()
+        coriolis_client = conf.get_coriolis_client()
+
+        if args.src_tenant_id:
+            src_tenant_name = source_client.get_project_name(
+                args.src_tenant_id)
+        elif args.src_tenant_name:
+            src_tenant_name = args.src_tenant_name
+
+        tenant_creation_payload = {
+            "tenant_name": src_tenant_name,
+            }
+        if args.no_instances:
+            tenant_creation_payload['instances'] = None
+        elif args.all_instances:
+            tenant_creation_payload['instances'] = []
+        elif args.instances:
+            tenant_creation_payload['instances'] = args.instances
+
+        tenant_creation_action = (
+            tenant_actions.WholeTenantCreationAction(
+                tenant_creation_payload,
+                source_openstack_client=source_client,
+                destination_openstack_client=destination_client,
+                coriolis_client=coriolis_client))
+
+        done = tenant_creation_action.check_already_done()
+        tenant = None
+        if done["done"]:
+            LOG.info(
+                "Tenant %s Creation seemingly done."
+                % done["result"])
+            tenant = {
+                'name': done["result"],
+                'id': destination_client.get_project_id(done["result"])}
+        else:
+            if args.not_drill:
+                tenant = tenant_creation_action.execute_operations()
+            else:
+                tenant_creation_action.print_operations()
+                tenant = {
+                    'id': 'NOT DONE',
+                    'name': 'NOT DONE'}
+
+        return TenantMigrationFormatter().list_objects([tenant])

--- a/coriolis_openstack_utils/resource_utils/instances.py
+++ b/coriolis_openstack_utils/resource_utils/instances.py
@@ -233,3 +233,8 @@ def get_migration_assessment(source_client, coriolis, migration_id):
         assessment["migration"]["previous_migrations"] = previous_migration_ids
 
     return assessment_list
+
+
+def list_instances(openstack_client, filters={}):
+    filters['all_tenants'] = True
+    return openstack_client.nova.servers.list(search_opts=filters)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ console_scripts =
     coriolis-openstack-util = coriolis_openstack_utils.cli.shell:main
 
 coriolis_openstack_utils =
+    migrate_tenant = coriolis_openstack_utils.cli.tenant:MigrateTenant
     migrate_router = coriolis_openstack_utils.cli.router:MigrateRouter
     migrate_user = coriolis_openstack_utils.cli.user:MigrateUser
     migrate_network = coriolis_openstack_utils.cli.network:MigrateNetwork


### PR DESCRIPTION
Wrapping up all my previous pull requests, the 'migrate tenant' subcommand migrates all components from the source openstack tenant: security groups, instances, networks, subnets and routers to a newly created tenant on the destination openstack.