### PR TITLE
Add support for carrying over static routes on Neutron Routers.

### DIFF
--- a/coriolis_openstack_utils/actions/network_actions.py
+++ b/coriolis_openstack_utils/actions/network_actions.py
@@ -301,6 +301,7 @@ class RouterCreationAction(base.BaseAction):
     param action_payload: dict(): payload (params) for the action
     must contain 'src_router_id'
                  'dest_tenant_id'
+                 'copy_routes' (default: False)
     """
 
     action_type = base.ACTION_TYPE_CHECK_CREATE_ROUTER
@@ -381,6 +382,14 @@ class RouterCreationAction(base.BaseAction):
             'dest_tenant_id']
         router_id = routers.create_router(
             self._destination_openstack_client, migr_info)
+
+        if self.payload.get('copy_routes') or CONF.destination.copy_routes:
+            src_routes = routers.get_source_routes(
+                self._source_openstack_client, self.payload['src_router_id'])
+            LOG.info(
+                "Adding routes '%s' to router '%s'" % (src_routes, router_id))
+            routers.add_routes_to_dest(
+                self._destination_openstack_client, src_routes, router_id)
 
         router = routers.get_router(
             self._destination_openstack_client, router_id)

--- a/coriolis_openstack_utils/cli/router.py
+++ b/coriolis_openstack_utils/cli/router.py
@@ -50,6 +50,9 @@ class MigrateRouter(lister.Lister):
             "--dest-tenant-name", dest="dest_tenant_name",
             help="The name of the destination tenant.")
         parser.add_argument(
+            "--copy-routes", dest="copy_routes", action="store_true",
+            help="Copy source static routes.")
+        parser.add_argument(
             "--not-a-drill", dest="not_drill", action="store_true",
             default=False,
             help="If unset, tooling will only print the indented operations.")
@@ -78,6 +81,9 @@ class MigrateRouter(lister.Lister):
         router_creation_payload = {
             'src_router_id': src_router_id,
             'dest_tenant_id': dest_tenant_id}
+
+        if args.copy_routes:
+            router_creation_payload['copy_routes'] = True
 
         router_creation_action = network_actions.RouterCreationAction(
             router_creation_payload,

--- a/coriolis_openstack_utils/conf.py
+++ b/coriolis_openstack_utils/conf.py
@@ -141,6 +141,9 @@ EXTERNAL_NETWORK_MAP_OPT = conf.DictOpt(
 NEW_USERS_PASSWORD_OPT = conf.StrOpt(
     "new_users_password",
     help="Default password for newly-migrated users.")
+COPY_ROUTES_OPT = conf.BoolOpt(
+    "copy_routes", default=False,
+    help="Whether to copy static routes from source routers.")
 
 
 # TODO (aznashwan): determine value of adding extra migration opts:
@@ -153,7 +156,7 @@ DESTINATION_OPTS = OPENSTACK_CONNECTION_OPTS + [
     NEW_SUBNAME_NAME_OPT, NEW_NETWORK_NAME_OPT, NEW_NETWORK_TYPE_OPT,
     NEW_PHYSICAL_NETWORK_OPT, NEW_ROUTER_NAME_OPT, EXTERNAL_NETWORK_MAP_OPT,
     NEW_USER_NAME_OPT, NEW_USERS_PASSWORD_OPT, SHUTDOWN_INSTANCES_OPT,
-    NEW_FLAVOR_NAME_OPT, NEW_KEYPAIR_NAME_OPT]
+    NEW_FLAVOR_NAME_OPT, NEW_KEYPAIR_NAME_OPT, COPY_ROUTES_OPT]
 CONF.register_opts(
     DESTINATION_OPTS, constants.DESTINATION_OPT_GROUP_NAME)
 

--- a/migration-config.conf.sample
+++ b/migration-config.conf.sample
@@ -81,3 +81,5 @@ new_tenant_neutron_quotas = security_group: -1
 new_tenant_open_default_secgroup = false
 # NOTE: only used when 'new_tenant_open_default_secgroup' is true:
 new_tenant_allowed_protocols = tcp, udp, icmp
+# whether to copy static routes from source routers
+copy_routes = False


### PR DESCRIPTION
Static routes are copied only if --copy-routes param is passed to CLI.
Resolves #30 